### PR TITLE
Ubuntu support

### DIFF
--- a/build-iso
+++ b/build-iso
@@ -8,16 +8,6 @@ ORIG="ubuntu-$VERSION-$DISTRO-$ARCH.iso"
 COPY="ubuntu-$VERSION-$DISTRO-$ARCH"
 ISO="$NICKNAME-ubuntu-$VERSION-$DISTRO-$ARCH.iso"
 
-case $(uname) in
-    'Linux')
-        PLATFORM='linux' ;;
-    'Darwin')
-        PLATFORM='osx' ;;
-    *)
-        echo "Unsupported platform: $(uname)"
-        exit 1 ;;
-esac
-
 # Download the original ISO if it isn't present already.
 [ -f "$ORIG" ] || curl -L -o "$ORIG" \
 	-d distro="$DISTRO" \

--- a/build-iso
+++ b/build-iso
@@ -8,6 +8,16 @@ ORIG="ubuntu-$VERSION-$DISTRO-$ARCH.iso"
 COPY="ubuntu-$VERSION-$DISTRO-$ARCH"
 ISO="$NICKNAME-ubuntu-$VERSION-$DISTRO-$ARCH.iso"
 
+case $(uname) in
+    'Linux')
+        PLATFORM='linux' ;;
+    'Darwin')
+        PLATFORM='osx' ;;
+    *)
+        echo "Unsupported platform: $(uname)"
+        exit 1 ;;
+esac
+
 # Download the original ISO if it isn't present already.
 [ -f "$ORIG" ] || curl -L -o "$ORIG" \
 	-d distro="$DISTRO" \
@@ -16,10 +26,23 @@ ISO="$NICKNAME-ubuntu-$VERSION-$DISTRO-$ARCH.iso"
 	"http://www.ubuntu.com/start-download"
 
 # Make a writable copy of the original ISO.
-mkdir -p mount
-sudo mount -o loop "$ORIG" mount
+case "$PLATFORM" in
+    'linux')
+        mkdir -p mount
+        sudo mount -o loop "$ORIG" mount ;;
+    'osx')
+        hdiutil attach -mountpoint "mount" "$ORIG" ;;
+esac
+
 rsync -a "mount/" "$COPY"
-sudo umount mount
+
+case "$PLATFORM" in
+    'linux')
+        sudo umount mount ;;
+    'osx')
+        hdiutil detach "mount" ;;
+esac
+
 chmod -R +w "$COPY"
 
 # Customize the writable copy.

--- a/build-iso
+++ b/build-iso
@@ -15,11 +15,11 @@ ISO="$NICKNAME-ubuntu-$VERSION-$DISTRO-$ARCH.iso"
 	-d bits="$([ "$ARCH" = "i386" ] && echo 32 || echo 64)" \
 	"http://www.ubuntu.com/start-download"
 
-# Make a writable copy of the original ISO.  This uses the `hdiutil`
-# command that is specific to Mac OS X.
-hdiutil attach -mountpoint "mount" "$ORIG"
+# Make a writable copy of the original ISO.
+mkdir -p mount
+sudo mount -o loop "$ORIG" mount
 rsync -a "mount/" "$COPY"
-hdiutil detach "mount"
+sudo umount mount
 chmod -R +w "$COPY"
 
 # Customize the writable copy.

--- a/clean-iso
+++ b/clean-iso
@@ -5,3 +5,5 @@ set -e
 . "$(dirname $0)/config.sh"
 
 rm -f "$NICKNAME-ubuntu-$VERSION-$DISTRO-$ARCH.iso"
+rm -rf "ubuntu-$VERSION-$DISTRO-$ARCH"
+rm -rf mount

--- a/config.sh
+++ b/config.sh
@@ -1,5 +1,16 @@
 #
 
+# Build platform details, for portability
+case $(uname) in
+    'Linux')
+        PLATFORM='linux' ;;
+    'Darwin')
+        PLATFORM='osx' ;;
+    *)
+        echo "Unsupported platform: $(uname)"
+        exit 1 ;;
+esac
+
 # The nickname of this ISO, VirtualBox image, and Vagrant box.
 : ${NICKNAME:="vagrant"}
 
@@ -30,6 +41,12 @@
 	-o StrictHostKeyChecking=no \
 	-l \"$USERNAME\" -i \"$PRIVATE_KEY\" -p \"$SSH_PORT\" localhost \
 "}
+
+# OpenSSH on Linux will refuse to use a world-readable private key.
+case "$PLATFORM" in
+    'linux')
+        chmod 600 "$PRIVATE_KEY" ;;
+esac
 
 # Fully-qualified pathname of VBoxGuestAdditions.iso.
 : ${VBOX_GUEST_ADDITIONS:="/Applications/VirtualBox.app/Contents/MacOS/VBoxGuestAdditions.iso"}


### PR DESCRIPTION
Don't know if you're interested in modifying this to support Linux, but if you are, here's a working version (tested on Ubuntu 10.04).

It introduces a switch on OS in a couple of places. I put some supporting code for this into `config.sh` because that seemed the sensible place for it. I don't have access to either a Mac or some other non-Linux machine, so I'm afraid the Mac case and the error case are untested.

I had to change two things.
1.  remove use of `hdiutil` for mounting the ISO
   -  I guess that it might be possible to use `mount` on OSX as well, in order to
     remove the conditional logic
2.  modify permissions on the private SSH key
   -  I wasn't sure where the best place to do this is; I put it in `config.sh` because
     that seems the only place that ensures it will get called before the first SSH
     operation (without restructuring the Makefile to introduce dependencies, or
     something); you may want to move it to somewhere more sensible
   -  again, you may want to get rid of the conditional logic here and do the `chmod`
     on the Mac as well

Hope this is useful to you.

-Ben
