### PR TITLE
include puppet support for vagrant boxes

### DIFF
--- a/build-vagrant
+++ b/build-vagrant
@@ -14,10 +14,10 @@ do
 	sleep 1
 done
 
-# Install Ruby, RubyGems, and Chef as Vagrant requires.
+# Install Puppet, Ruby, RubyGems, and Chef as Vagrant requires.
 # eval "$SSH \"
 # 	set -e
-# 	sudo apt-get -y install build-essential ruby-dev rubygems
+# 	sudo apt-get -y install build-essential ruby-dev rubygems puppet
 # 	sudo gem install --no-rdoc --no-ri chef
 # 	echo 'PATH=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/gems/1.8/bin\"' | sudo tee /etc/environment >/dev/null
 # \""


### PR DESCRIPTION
this allows out of the box usage of puppet as provisioning system with vagrant (http://vagrantup.com/docs/provisioners/puppet.html).

btw: why are these lines commented out by default?
