### PR TITLE
fix build-iso on osx 10.7 (lion)

### DIFF
--- a/build-iso
+++ b/build-iso
@@ -15,14 +15,22 @@ ISO="$NICKNAME-ubuntu-$VERSION-$DISTRO-$ARCH.iso"
 	-d bits="$([ "$ARCH" = "i386" ] && echo 32 || echo 64)" \
 	"http://www.ubuntu.com/start-download"
 
-# Make a writable copy of the original ISO.  This uses the `hdiutil`
-# command that is specific to Mac OS X.
-hdiutil attach -mountpoint "mount" "$ORIG" || {
+# Make a writable copy of the original ISO.
+{
+	# os x
+	sudo /usr/libexec/vndevice attach /dev/vn0 "$ORIG"
+	sudo mount -t cd9660 /dev/vn0 "mount"
+} || {
+	# linux
+	rm -rf "mount"
 	mkdir "mount"
 	sudo mount -o loop "$ORIG" "mount"
 }
 rsync -a "mount/" "$COPY"
-hdiutil detach "mount" || {
+{
+	sudo diskutil unmount "mount"
+	sudo /usr/libexec/vndevice detach /dev/vn0
+} || {
 	sudo umount "mount"
 	rm -rf "mount"
 }

--- a/build-vbox
+++ b/build-vbox
@@ -29,18 +29,8 @@ VBoxManage modifyvm "$VBOX" \
 	--audio none \
 	--clipboard disabled \
 	--usb off --usbehci off \
-	--vrdp off \
+	--vrde off \
 	--teleporter off
-
-# Mount the custom installation ISO.
-VBoxManage openmedium dvd "$PWD/$ISO" || true
-VBoxManage storagectl "$VBOX" \
-	--name IDE \
-	--add ide
-VBoxManage storageattach "$VBOX" \
-	--storagectl IDE \
-	--port 1 --device 0 \
-	--type dvddrive --medium "$PWD/$ISO"
 
 # Mount a virtual hard disk.
 VBoxManage createhd \
@@ -56,9 +46,17 @@ VBoxManage storageattach "$VBOX" \
 	--port 0 --device 0 \
 	--type hdd --medium "$PWD/$VBOX/$VBOX.vmdk"
 
+# "Insert" install iso into virtual cd drive
+VBoxManage storageattach "$VBOX" \
+       --storagectl SATA \
+       --port 1 --device 0 \
+       --type dvddrive --medium "$PWD/$ISO"
+
+
 # Start the virtual machine and the OS installation.  This will take
 # a while so this time it gets a GUI.  Spin slowly until SSH is usable.
 VBoxManage startvm "$VBOX" --type gui
+echo "Waiting for installion to finish.."
 until eval "$SSH exit"
 do
 	sleep 60
@@ -68,7 +66,7 @@ done
 # installation ISO in the process.  Install the additions and empty
 # the drive.
 VBoxManage storageattach "$VBOX" \
-	--storagectl IDE \
+	--storagectl SATA \
 	--port 1 --device 0 \
 	--type dvddrive --medium "$VBOX_GUEST_ADDITIONS"
 eval "$SSH \"

--- a/config.sh
+++ b/config.sh
@@ -8,7 +8,7 @@
 : ${DISTRO:="server"}
 : ${RELEASE:="latest"}
 
-# Architecture being built.
+# Architecture being built (i386 or amd64).
 : ${ARCH:="i386"}
 
 # Hardcoded host information.


### PR DESCRIPTION
the "fixed mount command on osx" commit fixes [issue #4](https://github.com/devstructure/ubuntu/issues/4)
the "added hint to frequently used architecture names" commit is only a small improvement to the documentation.

please pull the changes upstream.
