### PR TITLE
fixed command to install guest additions

### DIFF
--- a/build-vbox
+++ b/build-vbox
@@ -76,10 +76,7 @@ eval "$SSH \"
 	do
 		sleep 1
 	done
-	sudo /media/cdrom/VBoxLinuxAdditions-$([ "$ARCH" = "i386" ] \
-		&& echo x86 \
-		|| echo amd64
-	).run
+	sudo /media/cdrom/VBoxLinuxAdditions.run
 	sudo umount /media/cdrom
 \""
 VBoxManage storageattach "$VBOX" \

--- a/build-vbox
+++ b/build-vbox
@@ -80,7 +80,7 @@ eval "$SSH \"
 	sudo umount /media/cdrom
 \""
 VBoxManage storageattach "$VBOX" \
-	--storagectl IDE \
+	--storagectl SATA \
 	--port 1 --device 0 \
 	--type dvddrive --medium emptydrive
 


### PR DESCRIPTION
the command is no longer called VBoxLinuxAdditions-x86.run or VBoxLinuxAdditions-amd64.run but simply VBoxLinuxAdditions.run
